### PR TITLE
fix drain fund vulnerability

### DIFF
--- a/contracts/SingularDTVToken.sol
+++ b/contracts/SingularDTVToken.sol
@@ -74,8 +74,8 @@ contract SingularDTVToken is StandardToken {
         returns (bool)
     {
         // Both parties withdraw their revenue first
-        singularDTVFund.softWithdrawRevenueFor(msg.sender);
-        singularDTVFund.softWithdrawRevenueFor(to);
+        if (!singularDTVFund.softWithdrawRevenueFor(msg.sender) || !singularDTVFund.softWithdrawRevenueFor(to))
+            throw;
         return super.transfer(to, value);
     }
 
@@ -89,8 +89,8 @@ contract SingularDTVToken is StandardToken {
         returns (bool)
     {
         // Both parties withdraw their revenue first
-        singularDTVFund.softWithdrawRevenueFor(from);
-        singularDTVFund.softWithdrawRevenueFor(to);
+        if (!singularDTVFund.softWithdrawRevenueFor(from) || !singularDTVFund.softWithdrawRevenueFor(to))
+            throw;
         return super.transferFrom(from, to, value);
     }
 


### PR DESCRIPTION
Calling `softWithdrawRevenueFor` can fail due to the 1024 call stack depth limit.
An attacker can use this to transfer tokens without calling `softWithdrawRevenueFor`. This can be used to completely drain the fund, by always calling `softWithdrawRevenueFor` after transferring the tokens.
`super.transfer/transferFrom` can be implemented as `JUMP` in the EVM since it does not need to `CALL` another contract, therefore it does not increase the call stack depth.